### PR TITLE
Fix crashes if error to be handled isn't String

### DIFF
--- a/lib/domain/usecases/log_http_request.dart
+++ b/lib/domain/usecases/log_http_request.dart
@@ -20,6 +20,6 @@ class LogHttpRequest extends UseCase<bool, HttpRequest> {
 
   @override
   Future<void> handleError(error) async {
-    debugPrint('$error');
+    debugPrint(error.toString());
   }
 }

--- a/lib/domain/usecases/log_http_request.dart
+++ b/lib/domain/usecases/log_http_request.dart
@@ -20,6 +20,6 @@ class LogHttpRequest extends UseCase<bool, HttpRequest> {
 
   @override
   Future<void> handleError(error) async {
-    debugPrint(error);
+    debugPrint('$error');
   }
 }

--- a/lib/domain/usecases/log_http_response.dart
+++ b/lib/domain/usecases/log_http_response.dart
@@ -20,6 +20,6 @@ class LogHttpResponse extends UseCase<bool, HttpResponse> {
 
   @override
   Future<void> handleError(error) async {
-    debugPrint(error);
+    debugPrint('$error');
   }
 }

--- a/lib/domain/usecases/log_http_response.dart
+++ b/lib/domain/usecases/log_http_response.dart
@@ -20,6 +20,6 @@ class LogHttpResponse extends UseCase<bool, HttpResponse> {
 
   @override
   Future<void> handleError(error) async {
-    debugPrint('$error');
+    debugPrint(error.toString());
   }
 }


### PR DESCRIPTION
## Description  
Fix crashes if error to be handled isn't String

## Type Of Task  
- Bug fix (non-breaking change which fixes an issue) 

## Preflight Checklist: 
- [x] This code already follow Standard Code & Community Guideline
- [x] This PR is self-reviewed before created 
- [ ] Added inline documentation on each update 
- [ ] I have made corresponding changes to the documentation 
- [x] This PR generate no new warnings